### PR TITLE
Normalize operator status field

### DIFF
--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -216,14 +216,13 @@ class Admin extends CI_Controller {
 			$ins['email'] = $this->input->post('email');
 			$ins['password'] = $password;
             $ins['tipologiaUtente'] = $this->input->post('tipologiaUtente');
-			$ins['stato'] = $this->input->post('stato');
-			$ins['autorizzazioni'] = '';
-			$ins['contatti'] = '';
-			$ins['avatar'] = $avatardefault;
-			$ins['nickname'] = '';
-			$ins['dipartimento'] = '';
-			$ins['userwallet'] = $this->input->post('wallet');
-			$ins['stato'] = $this->input->post('status');
+                        $ins['stato'] = $this->input->post('stato');
+                        $ins['autorizzazioni'] = '';
+                        $ins['contatti'] = '';
+                        $ins['avatar'] = $avatardefault;
+                        $ins['nickname'] = '';
+                        $ins['dipartimento'] = '';
+                        $ins['userwallet'] = $this->input->post('wallet');
 			$this->db->insert('utenti',$ins);
 			redirect('admin/listoperator');exit;
 
@@ -284,7 +283,7 @@ class Admin extends CI_Controller {
 			 $ins['autorizzazioni '] = $this->input->post('autorizzazioni');
 			 $ins['contatti'] = $this->input->post('contatti');
 			 $ins['dipartimento'] = $this->input->post('dipartimento'); 
-			 $ins['stato'] = $this->input->post('status'); 
+                        $ins['stato'] = $this->input->post('stato');
 			 $ins['nickname'] = $this->input->post('nickname'); 
 			 $ins['userwallet '] = $this->input->post('wallet');
 			 //echo "<pre>";print_r($ins);die;

--- a/application/views/admin/archive.php
+++ b/application/views/admin/archive.php
@@ -216,14 +216,13 @@ class Admin extends CI_Controller {
 			$ins['email'] = $this->input->post('email');
 			$ins['password'] = $password;
             $ins['tipologiaUtente'] = $this->input->post('tipologiaUtente');
-			$ins['stato'] = $this->input->post('stato');
-			$ins['autorizzazioni'] = '';
-			$ins['contatti'] = '';
-			$ins['avatar'] = $avatardefault;
-			$ins['nickname'] = '';
-			$ins['dipartimento'] = '';
-			$ins['userwallet'] = $this->input->post('wallet');
-			$ins['stato'] = $this->input->post('status');
+                        $ins['stato'] = $this->input->post('stato');
+                        $ins['autorizzazioni'] = '';
+                        $ins['contatti'] = '';
+                        $ins['avatar'] = $avatardefault;
+                        $ins['nickname'] = '';
+                        $ins['dipartimento'] = '';
+                        $ins['userwallet'] = $this->input->post('wallet');
 			$this->db->insert('utenti',$ins);
 			redirect('admin/listoperator');exit;
 
@@ -284,7 +283,7 @@ class Admin extends CI_Controller {
 			 $ins['autorizzazioni '] = $this->input->post('autorizzazioni');
 			 $ins['contatti'] = $this->input->post('contatti');
 			 $ins['dipartimento'] = $this->input->post('dipartimento'); 
-			 $ins['stato'] = $this->input->post('status'); 
+                         $ins['stato'] = $this->input->post('stato');
 			 $ins['nickname'] = $this->input->post('nickname'); 
 			 $ins['userwallet '] = $this->input->post('wallet');
 			 //echo "<pre>";print_r($ins);die;

--- a/application/views/admin/editoperator.php
+++ b/application/views/admin/editoperator.php
@@ -135,20 +135,20 @@
 								<div class="form-group row">
 								<label for="jsValidationLengthMax" class="form-label col-3"> Status</label>
 									
-									<label class="form-radio-custom">
-										<input type="radio" name="status" value="0"  <?php if($userinfo->stato==0) echo "checked"; ?>>
-										<span class="form-label">Inactive</span>
-										
-									</label>
-									<label class="form-radio-custom">
-										<input type="radio" name="status" value="1" <?php if($userinfo->stato==1) echo "checked"; ?>>
-										<span class="form-label">Active</span>
-									</label>
-									<label class="form-radio-custom">
-										<input type="radio" name="status" value="2" <?php if($userinfo->stato==2) echo "checked"; ?>>
-										<span class="form-label">Blocked</span>
-									</label>
-								</div>
+                                                                        <label class="form-radio-custom">
+                                                                                <input type="radio" name="stato" value="0"  <?php if($userinfo->stato==0) echo "checked"; ?>>
+                                                                                <span class="form-label">Inactive</span>
+
+                                                                        </label>
+                                                                        <label class="form-radio-custom">
+                                                                                <input type="radio" name="stato" value="1" <?php if($userinfo->stato==1) echo "checked"; ?>>
+                                                                                <span class="form-label">Active</span>
+                                                                        </label>
+                                                                        <label class="form-radio-custom">
+                                                                                <input type="radio" name="stato" value="2" <?php if($userinfo->stato==2) echo "checked"; ?>>
+                                                                                <span class="form-label">Blocked</span>
+                                                                        </label>
+                                                                </div>
 								
 							</div>
 							

--- a/application/views/admin/enableoperator.php
+++ b/application/views/admin/enableoperator.php
@@ -117,20 +117,20 @@
 								<div class="form-group row">
 								<label for="jsValidationLengthMax" class="form-label col-3"> Status</label>
 									
-									<label class="form-radio-custom">
-										<input type="radio" name="status" value="0">
-										<span class="form-label">Inactive</span>
-										
-									</label>
-									<label class="form-radio-custom">
-										<input type="radio" name="status" value="1">
-										<span class="form-label">Active</span>
-									</label>
-									<label class="form-radio-custom">
-										<input type="radio" name="status" value="2">
-										<span class="form-label">Blocked</span>
-									</label>
-								</div>
+                                                                        <label class="form-radio-custom">
+                                                                                <input type="radio" name="stato" value="0">
+                                                                                <span class="form-label">Inactive</span>
+
+                                                                        </label>
+                                                                        <label class="form-radio-custom">
+                                                                                <input type="radio" name="stato" value="1">
+                                                                                <span class="form-label">Active</span>
+                                                                        </label>
+                                                                        <label class="form-radio-custom">
+                                                                                <input type="radio" name="stato" value="2">
+                                                                                <span class="form-label">Blocked</span>
+                                                                        </label>
+                                                               </div>
 								
 							</div>
 							


### PR DESCRIPTION
## Summary
- remove redundant operator status assignment and accept `stato` from the form
- rename operator status fields in create/edit forms to `stato`
- update edit handler to read the unified `stato` field

## Testing
- `php -l application/controllers/Admin.php`
- `php -l application/views/admin/enableoperator.php`
- `php -l application/views/admin/editoperator.php`
- `php -l application/views/admin/archive.php`
- `composer install` *(fails: require-dev.mikey179/vfsStream invalid)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b139a836083329eda56a336d36d3f