### PR TITLE
Refactor getAllFromWhere to use array conditions

### DIFF
--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -47,10 +47,10 @@ class Admin extends CI_Controller {
 			if($_SESSION['logged_incheck']['tipologiaUtente']=='admin'){
 				$data['certificat'] = $this->model_object->getAll('contenuto_certificato');	
 			}else{
-                $data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato','operatore="'.$_SESSION['logged_incheck']['id'].'"');
+               $data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato', ['operatore' => $_SESSION['logged_incheck']['id']]);
 			}
 			$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
-			$data['userdata'] = $this->model_object->getAllFromWhere('utenti','`id`<> 1');
+               $data['userdata'] = $this->model_object->getAllFromWhere('utenti', ['id <>' => 1]);
 			
 			//echo "<pre>";print_r($_SESSION['logged_incheck']);echo $_SESSION['logged_incheck']['dipartimento '];die;
 	   		$this->load->view('admin/adminheader',$data);
@@ -184,7 +184,7 @@ class Admin extends CI_Controller {
 			$data['unicode']= $unicode;
 			$data['title'] = "Archive";
 			$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
-			$data['files'] = $this->model_object->getAllFromWhere('cartelle_utenti','user="'.$_SESSION['logged_incheck']['id'].'"');
+                   $data['files'] = $this->model_object->getAllFromWhere('cartelle_utenti', ['user' => $_SESSION['logged_incheck']['id']]);
 			//$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
 			$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
 	   		$this->load->view('admin/adminheader',$data);
@@ -197,7 +197,7 @@ class Admin extends CI_Controller {
 	 
 	public function deletefile($id){
 		$id = $id;
-		$delfiles = $this->model_object->getAllFromWhere('contenuto_certificato','id="'.$id.'"');
+           $delfiles = $this->model_object->getAllFromWhere('contenuto_certificato', ['id' => $id]);
 		$this->db->delete('archivio', array('original' => $delfiles[0]->path));
 		$this->db->delete('registro', array('path' => $delfiles[0]->path));
 		$this->db->delete('contenuto_certificato', array('id' => $id));
@@ -533,7 +533,7 @@ class Admin extends CI_Controller {
 		    if(file_exists($dir)){
 				$b = scandir($dir,1);//print_r($b);die;
 			}
-			$data['files'] = $this->model_object->getAllFromWhere('cartelle_utenti','user="'.$_SESSION['logged_incheck']['id'].'"');
+                   $data['files'] = $this->model_object->getAllFromWhere('cartelle_utenti', ['user' => $_SESSION['logged_incheck']['id']]);
 		    //$data['files'] = $b;
 			$data['department'] = $this->model_object->getAll('dipartimenti');
 			$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
@@ -584,7 +584,7 @@ class Admin extends CI_Controller {
 
 		$ip=$_SERVER['REMOTE_ADDR'];
 		$date=date("d/m/Y H:i");
-		$q=$this->model_object->getAllFromWhere('contenuto_certificato','hex="'.$_GET[h].'"');
+           $q = $this->model_object->getAllFromWhere('contenuto_certificato', ['hex' => $_GET['h']]);
 		//$q=mysql_query("SELECT * FROM contenuto_certificato WHERE hex='$_GET[h]'");
 		//$r=mysql_fetch_array($q);
 		$u=mysql_query("SELECT * FROM comunicazioni_visure");
@@ -624,7 +624,7 @@ class Admin extends CI_Controller {
 		if($_SESSION['logged_incheck']['tipologiaUtente']=='admin'){
 			$data['certificat'] = $this->model_object->getAll('contenuto_certificato');	
 		}else{
-			$data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato','operatore="'.$_SESSION['logged_incheck']['id'].'"');
+                   $data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato', ['operatore' => $_SESSION['logged_incheck']['id']]);
 		}
 		//echo "<pre>";print_r($data['certificat']);die;
 		$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
@@ -638,7 +638,7 @@ class Admin extends CI_Controller {
 	public function certifyfile(){ //die();
 		$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
 		
-	    $data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato','id="'.$this->input->get('docid').'"');
+       $data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato', ['id' => $this->input->get('docid')]);
 	    $data['docid'] = $this->input->get('docid');
 		$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
 		//print_r($data['certificat']);die;
@@ -688,7 +688,7 @@ class Admin extends CI_Controller {
 		}
 			$data['title'] = "Message encryption";
 			$data['title1'] = "Retrieve sha256 code";
-			$data['message'] = $this->model_object->getAllFromWhere('messaggi',"`operatore`='".$_SESSION['logged_incheck']['id']."'");
+                   $data['message'] = $this->model_object->getAllFromWhere('messaggi', ['operatore' => $_SESSION['logged_incheck']['id']]);
 			$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
 			$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
 			$this->load->view('admin/adminheader',$data);

--- a/application/controllers/Install.php
+++ b/application/controllers/Install.php
@@ -89,7 +89,7 @@ class Install extends CI_Controller {
 		public function unlock(){ //print_r($_SESSION);die;
 
          	$this->load->model('model_object');
-            $data['user'] = $this->model_object->getAllFromWhere('utenti',"`login_status`= 1 and `login_time`<=0");
+           $data['user'] = $this->model_object->getAllFromWhere('utenti', ['login_status' => 1, 'login_time <=' => 0]);
            
 		    $data['user'] = $data['user'][0]->email;
 

--- a/application/controllers/Signin.php
+++ b/application/controllers/Signin.php
@@ -114,7 +114,7 @@ class Signin extends CI_Controller {
                     'login_status' => 1
                 ]);
 
-                $getexpiry = $this->model_object->getAllFromWhere('contenuto_certificato', 'scadenza <= ' . date('d/m/Y'));
+               $getexpiry = $this->model_object->getAllFromWhere('contenuto_certificato', ['scadenza <=' => date('d/m/Y')]);
                 foreach ($getexpiry as $filedel) {
                     $this->db->delete('contenuto_certificato', ['id' => $filedel->id]);
                     $this->db->delete('archivio', ['original' => $filedel->path]);
@@ -317,7 +317,7 @@ class Signin extends CI_Controller {
 			 $ins['login_time'] = time();
 			 $ins['login_status'] = 1;
 			 $this->db->update("utenti",$ins);
-			 $getexpiry = $this->model_object->getAllFromWhere('contenuto_certificato','scadenza <= '.date('d/m/Y'));
+                        $getexpiry = $this->model_object->getAllFromWhere('contenuto_certificato', ['scadenza <=' => date('d/m/Y')]);
 			 foreach($getexpiry as $filedel){//print_r($filedel);
 				$this->db->delete('contenuto_certificato', array('id' => $filedel->id));
 				$this->db->delete('archivio', array('original' => $filedel->path));

--- a/application/models/Model_object.php
+++ b/application/models/Model_object.php
@@ -33,20 +33,19 @@ class model_object extends CI_Model
 	    $query = $this->db->get();   
 	    return $query->result();	
     } 
-	function getAllFromWhere($table,$where)
+       function getAllFromWhere($table, $conditions = array())
     {
-		
-	    $query=$this->db->query("SELECT * FROM ".$table." where ".$where); 
-	    return $query->result();	
-		
-    } 
-    function getAllFromWhereParticular($table,$where,$particular)
+            $query = $this->db->get_where($table, $conditions);
+            return $query->result();
+
+    }
+    function getAllFromWhereParticular($table, $conditions, $particular)
     {
-		
-	    $query=$this->db->query("SELECT ".$particular." FROM ".$table." where ".$where); 
-	    return $query->row();	
-		
-    } 
+            $this->db->select($particular);
+            $query = $this->db->get_where($table, $conditions);
+            return $query->row();
+
+    }
 	function getAllByStatus($table)
     {
 	    $this->db->select('*');

--- a/application/views/admin/archive.php
+++ b/application/views/admin/archive.php
@@ -47,10 +47,10 @@ class Admin extends CI_Controller {
 			if($_SESSION['logged_incheck']['tipologiaUtente']=='admin'){
 				$data['certificat'] = $this->model_object->getAll('contenuto_certificato');	
 			}else{
-                $data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato','operatore="'.$_SESSION['logged_incheck']['id'].'"');
+               $data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato', ['operatore' => $_SESSION['logged_incheck']['id']]);
 			}
 			$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
-			$data['userdata'] = $this->model_object->getAllFromWhere('utenti','`id`<> 1');
+               $data['userdata'] = $this->model_object->getAllFromWhere('utenti', ['id <>' => 1]);
 			
 			//echo "<pre>";print_r($_SESSION['logged_incheck']);echo $_SESSION['logged_incheck']['dipartimento '];die;
 	   		$this->load->view('admin/adminheader',$data);
@@ -184,7 +184,7 @@ class Admin extends CI_Controller {
 			$data['unicode']= $unicode;
 			$data['title'] = "Archive";
 			$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
-			$data['files'] = $this->model_object->getAllFromWhere('cartelle_utenti','user="'.$_SESSION['logged_incheck']['id'].'"');
+                   $data['files'] = $this->model_object->getAllFromWhere('cartelle_utenti', ['user' => $_SESSION['logged_incheck']['id']]);
 			//$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
 			$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
 	   		$this->load->view('admin/adminheader',$data);
@@ -197,7 +197,7 @@ class Admin extends CI_Controller {
 	 
 	public function deletefile($id){
 		$id = $id;
-		$delfiles = $this->model_object->getAllFromWhere('contenuto_certificato','id="'.$id.'"');
+           $delfiles = $this->model_object->getAllFromWhere('contenuto_certificato', ['id' => $id]);
 		$this->db->delete('archivio', array('original' => $delfiles[0]->path));
 		$this->db->delete('registro', array('path' => $delfiles[0]->path));
 		$this->db->delete('contenuto_certificato', array('id' => $id));
@@ -533,7 +533,7 @@ class Admin extends CI_Controller {
 		    if(file_exists($dir)){
 				$b = scandir($dir,1);//print_r($b);die;
 			}
-			$data['files'] = $this->model_object->getAllFromWhere('cartelle_utenti','user="'.$_SESSION['logged_incheck']['id'].'"');
+                   $data['files'] = $this->model_object->getAllFromWhere('cartelle_utenti', ['user' => $_SESSION['logged_incheck']['id']]);
 		    //$data['files'] = $b;
 			$data['department'] = $this->model_object->getAll('dipartimenti');
 			$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
@@ -584,7 +584,7 @@ class Admin extends CI_Controller {
 
 		$ip=$_SERVER['REMOTE_ADDR'];
 		$date=date("d/m/Y H:i");
-		$q=$this->model_object->getAllFromWhere('contenuto_certificato','hex="'.$_GET[h].'"');
+           $q = $this->model_object->getAllFromWhere('contenuto_certificato', ['hex' => $_GET['h']]);
 		//$q=mysql_query("SELECT * FROM contenuto_certificato WHERE hex='$_GET[h]'");
 		//$r=mysql_fetch_array($q);
 		$u=mysql_query("SELECT * FROM comunicazioni_visure");
@@ -624,7 +624,7 @@ class Admin extends CI_Controller {
 		if($_SESSION['logged_incheck']['tipologiaUtente']=='admin'){
 			$data['certificat'] = $this->model_object->getAll('contenuto_certificato');	
 		}else{
-			$data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato','operatore="'.$_SESSION['logged_incheck']['id'].'"');
+                   $data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato', ['operatore' => $_SESSION['logged_incheck']['id']]);
 		}
 		//echo "<pre>";print_r($data['certificat']);die;
 		$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
@@ -638,7 +638,7 @@ class Admin extends CI_Controller {
 	public function certifyfile(){ //die();
 		$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
 		
-	    $data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato','id="'.$this->input->get('docid').'"');
+       $data['certificat'] = $this->model_object->getAllFromWhere('contenuto_certificato', ['id' => $this->input->get('docid')]);
 	    $data['docid'] = $this->input->get('docid');
 		$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
 		//print_r($data['certificat']);die;
@@ -688,7 +688,7 @@ class Admin extends CI_Controller {
 		}
 			$data['title'] = "Message encryption";
 			$data['title1'] = "Retrieve sha256 code";
-			$data['message'] = $this->model_object->getAllFromWhere('messaggi',"`operatore`='".$_SESSION['logged_incheck']['id']."'");
+                   $data['message'] = $this->model_object->getAllFromWhere('messaggi', ['operatore' => $_SESSION['logged_incheck']['id']]);
 			$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
 			$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
 			$this->load->view('admin/adminheader',$data);


### PR DESCRIPTION
## Summary
- Refactor `Model_object::getAllFromWhere` and `getAllFromWhereParticular` to accept key–value arrays and leverage CodeIgniter's query builder
- Update controllers and views to pass structured condition arrays instead of raw SQL strings
- Replace manual string concatenation with `$this->db->get_where()`

## Testing
- `php -l application/models/Model_object.php`
- `php -l application/controllers/Admin.php`
- `php -l application/controllers/Install.php`
- `php -l application/controllers/Signin.php`
- `php -l application/views/admin/archive.php`
- `composer install` (fails: require-dev.mikey179/vfsStream is invalid)
- `vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689b13936ab48332823873598ebf9736