### PR TITLE
Refactor getAllFromWhere for array conditions

### DIFF
--- a/application/models/Model_object.php
+++ b/application/models/Model_object.php
@@ -33,20 +33,27 @@ class model_object extends CI_Model
 	    $query = $this->db->get();   
 	    return $query->result();	
     } 
-	function getAllFromWhere($table,$where)
+        function getAllFromWhere($table,$where)
     {
-		
-	    $query=$this->db->query("SELECT * FROM ".$table." where ".$where); 
-	    return $query->result();	
-		
-    } 
+            if (is_array($where)) {
+                $query = $this->db->get_where($table, $where);
+            } else {
+                $query = $this->db->query("SELECT * FROM ".$table." where ".$where);
+            }
+            return $query->result();
+
+    }
     function getAllFromWhereParticular($table,$where,$particular)
     {
-		
-	    $query=$this->db->query("SELECT ".$particular." FROM ".$table." where ".$where); 
-	    return $query->row();	
-		
-    } 
+            if (is_array($where)) {
+                $this->db->select($particular);
+                $query = $this->db->get_where($table, $where);
+            } else {
+                $query=$this->db->query("SELECT ".$particular." FROM ".$table." where ".$where);
+            }
+            return $query->row();
+
+    }
 	function getAllByStatus($table)
     {
 	    $this->db->select('*');


### PR DESCRIPTION
## Summary
- allow getAllFromWhere to accept associative arrays via query builder
- support array conditions in getAllFromWhereParticular

## Testing
- `php -l application/models/Model_object.php`
- `composer install` *(fails: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters)*

------
https://chatgpt.com/codex/tasks/task_e_689b1aeb5dec8332888659a13c5e39b6