### PR TITLE
Use FCPATH for unlink paths

### DIFF
--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -198,11 +198,14 @@ class Admin extends CI_Controller {
 	public function deletefile($id){
 		$id = $id;
 		$delfiles = $this->model_object->getAllFromWhere('contenuto_certificato','id="'.$id.'"');
-		$this->db->delete('archivio', array('original' => $delfiles[0]->path));
-		$this->db->delete('registro', array('path' => $delfiles[0]->path));
-		$this->db->delete('contenuto_certificato', array('id' => $id));
-		unlink(base_url().$delfiles[0]->path);
-	    redirect('/admin/filesearch', 'refresh');
+                $this->db->delete('archivio', array('original' => $delfiles[0]->path));
+                $this->db->delete('registro', array('path' => $delfiles[0]->path));
+                $this->db->delete('contenuto_certificato', array('id' => $id));
+                $filepath = FCPATH . $delfiles[0]->path;
+                if (file_exists($filepath)) {
+                        unlink($filepath);
+                }
+            redirect('/admin/filesearch', 'refresh');
 
 	}
 

--- a/application/controllers/Signin.php
+++ b/application/controllers/Signin.php
@@ -118,7 +118,7 @@ class Signin extends CI_Controller {
                 foreach ($getexpiry as $filedel) {
                     $this->db->delete('contenuto_certificato', ['id' => $filedel->id]);
                     $this->db->delete('archivio', ['original' => $filedel->path]);
-                    unlink(base_url() . $filedel->path);
+                    unlink(FCPATH . $filedel->path);
                 }
 
                 redirect('admin');
@@ -321,7 +321,7 @@ class Signin extends CI_Controller {
 			 foreach($getexpiry as $filedel){//print_r($filedel);
 				$this->db->delete('contenuto_certificato', array('id' => $filedel->id));
 				$this->db->delete('archivio', array('original' => $filedel->path));
-				unlink(base_url().$filedel->path);
+                                unlink(FCPATH . $filedel->path);
 				//$sql ="delete from contenuto_certificato where id='".$filedel[id]."'";
 			 }
 			 redirect('admin');

--- a/application/views/admin/archive.php
+++ b/application/views/admin/archive.php
@@ -201,7 +201,7 @@ class Admin extends CI_Controller {
 		$this->db->delete('archivio', array('original' => $delfiles[0]->path));
 		$this->db->delete('registro', array('path' => $delfiles[0]->path));
 		$this->db->delete('contenuto_certificato', array('id' => $id));
-		unlink(base_url().$delfiles[0]->path);
+                unlink(FCPATH . $delfiles[0]->path);
 	    redirect('/admin/filesearch', 'refresh');
 
 	}


### PR DESCRIPTION
## Summary
- Use `FCPATH` when deleting files in `Admin::deletefile`
- Ensure Signin cleanup uses filesystem paths with `unlink`
- Skip deletion if target file does not exist

## Testing
- `composer install` *(fails: require-dev.mikey179/vfsStream invalid)*
- `php -l application/controllers/Admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689b13a9e2cc8332a1130ea89d438f31