### PR TITLE
Refactor exist check and add tests

### DIFF
--- a/application/models/Model_object.php
+++ b/application/models/Model_object.php
@@ -132,13 +132,9 @@ class model_object extends CI_Model
    }
   function exist($field,$table,$value)
    {
-     $this->db->get($table);
-	 $query=$this->db->where($field,$value);
-	 if($query->num_rows()>0)
-	 return true;
-	 else
-	 return false;
-	 
+     $query = $this->db->get_where($table, [$field => $value]);
+     return $query->num_rows() > 0;
+
    }
    
    function getElementByField($field,$table,$value)

--- a/tests/ModelObjectExistTest.php
+++ b/tests/ModelObjectExistTest.php
@@ -1,0 +1,41 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('CI_Model')) {
+    class CI_Model {}
+}
+
+require_once __DIR__ . '/../application/models/Model_object.php';
+
+class ModelObjectExistTest extends TestCase
+{
+    private function getModelWithNumRows($num)
+    {
+        $query = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['num_rows'])
+            ->getMock();
+        $query->method('num_rows')->willReturn($num);
+
+        $db = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['get_where'])
+            ->getMock();
+        $db->method('get_where')->willReturn($query);
+
+        $ref = new ReflectionClass('model_object');
+        $model = $ref->newInstanceWithoutConstructor();
+        $model->db = $db;
+        return $model;
+    }
+
+    public function testExistReturnsTrueWhenRecordPresent()
+    {
+        $model = $this->getModelWithNumRows(1);
+        $this->assertTrue($model->exist('field', 'table', 'value'));
+    }
+
+    public function testExistReturnsFalseWhenRecordAbsent()
+    {
+        $model = $this->getModelWithNumRows(0);
+        $this->assertFalse($model->exist('field', 'table', 'value'));
+    }
+}


### PR DESCRIPTION
## Summary
- Simplify `Model_object::exist` using `get_where` and boolean return
- Add PHPUnit tests for existing and missing records

## Testing
- `php phpunit.phar tests/ModelObjectExistTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689b224f65388332aeadb505a1e2fb6c