### PR TITLE
Clean up debug code in Admin controller index

### DIFF
--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -55,14 +55,9 @@ class Admin extends CI_Controller {
 			$data['offcdata'] = $this->model_object->getElementById('dati_ufficio',1);
 			$data['userdata'] = $this->model_object->getAllFromWhere('utenti','`id`<> 1');
 			
-			//echo "<pre>";print_r($_SESSION['logged_incheck']);echo $_SESSION['logged_incheck']['dipartimento '];die;
-	   		$this->load->view('admin/adminheader',$data);
-			$this->load->view('admin/dashboard',$data);
-			$this->load->view('admin/adminfooter',$data);
-		
-		
-
-		//$this->load->view('footer');
+                        $this->load->view('admin/adminheader',$data);
+                        $this->load->view('admin/dashboard',$data);
+                        $this->load->view('admin/adminfooter',$data);
 	}
 
 	public function unlock(){


### PR DESCRIPTION
## Summary
- remove leftover session debug line and dead footer call in `Admin` controller

## Testing
- `composer install`
- `./vendor/bin/phpunit tests` *(fails: Call to undefined function each())*
- `php -l application/controllers/Admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689b465c392c8332a0be37dba0501a9a