### PR TITLE
Remove debug print from archive view options

### DIFF
--- a/application/views/admin/archive.php
+++ b/application/views/admin/archive.php
@@ -42,7 +42,7 @@
                             </label>
                             <select name="folder" class="form-control">
                                 <option value="">Select</option>
-                                <?php foreach($files as $fol){echo "<pre>";print_r($fol)?>
+                                <?php foreach($files as $fol){?>
                                     <option value="<?php echo $fol->cartella;?>"><?php echo $fol->cartella;?></option>
                                 <?php }?>
                             </select>


### PR DESCRIPTION
## Summary
- clean up folder dropdown in `archive.php`

## Testing
- `php -l application/views/admin/archive.php`
- `./vendor/bin/phpunit --testdox` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b465b0a248332be223f43c3fb246b