### PR TITLE
chore: update Bootstrap to 5.3.3

### DIFF
--- a/application/views/admin/home.php
+++ b/application/views/admin/home.php
@@ -12,8 +12,6 @@
     <!-- Custom Stylesheet -->
     <link rel="stylesheet" href="<?=base_url();?>assets/vendor/waves/waves.min.css">
     <link rel="stylesheet" href="<?=base_url();?>assets/vendor/owlcarousel/css/owl.carousel.min.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <link rel="stylesheet" href="<?=base_url();?>assets/css/style.css">
 </head>
 

--- a/application/views/admin/signin.php
+++ b/application/views/admin/signin.php
@@ -12,8 +12,6 @@
     <!-- Custom Stylesheet -->
     <link rel="stylesheet" href="<?=base_url();?>assets/vendor/waves/waves.min.css">
     <link rel="stylesheet" href="<?=base_url();?>assets/vendor/owlcarousel/css/owl.carousel.min.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <link rel="stylesheet" href="<?=base_url();?>assets/css/style.css">
 </head>
 

--- a/application/views/admin/signup.php
+++ b/application/views/admin/signup.php
@@ -12,8 +12,6 @@
     <!-- Custom Stylesheet -->
     <link rel="stylesheet" href="<?=base_url();?>assets/vendor/waves/waves.min.css">
     <link rel="stylesheet" href="<?=base_url();?>assets/vendor/owlcarousel/css/owl.carousel.min.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <link rel="stylesheet" href="<?=base_url();?>assets/css/style.css">
 </head>
 

--- a/application/views/header.php
+++ b/application/views/header.php
@@ -33,8 +33,8 @@
 	<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900" rel="stylesheet">
 
         <link href="https://fonts.googleapis.com/css?family=Montserrat:700" rel="stylesheet">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
         <link rel="stylesheet" href="<?=base_url()?>/assets/css/main.css">
     <script src='https://www.google.com/recaptcha/api.js'></script>
 	<style>

--- a/application/views/signup.php
+++ b/application/views/signup.php
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sign Up</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <link rel="stylesheet" href="<?=base_url();?>assets/css/style.css">
 </head>
 <body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bootstrap Sidebar</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="css/style.css">
 </head>
@@ -40,7 +40,7 @@
 </div>
 
 <script src="js/script.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- remove Bootstrap 5.3.2 links from admin pages and consolidate on 5.3.3
- update Bootstrap references in shared templates and dist example

## Testing
- `./vendor/bin/phpunit` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b4b0746dc83328711702aa74752f2