### PR TITLE
Update dist example to Bootstrap 5.3.3

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -1,0 +1,15 @@
+body {
+  overflow-x: hidden;
+}
+
+#sidebar {
+  min-height: 100vh;
+}
+
+#sidebar .nav-link {
+  color: #333;
+}
+
+#sidebar .nav-link.active {
+  font-weight: 500;
+}

--- a/dist/index.html
+++ b/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bootstrap Sidebar</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="css/style.css">
 </head>
@@ -40,7 +40,7 @@
 </div>
 
 <script src="js/script.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>
 

--- a/dist/js/script.js
+++ b/dist/js/script.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const toggleButton = document.getElementById('toggleButton');
+  const sidebar = document.getElementById('sidebar');
+  const main = document.getElementById('main');
+
+  toggleButton.addEventListener('click', () => {
+    sidebar.classList.toggle('d-none');
+    main.classList.toggle('col-md-9');
+    main.classList.toggle('col-lg-10');
+    main.classList.toggle('col-md-12');
+    main.classList.toggle('col-lg-12');
+  });
+});


### PR DESCRIPTION
## Summary
- update dist/index.html to Bootstrap 5.3.3 CDN links
- add accompanying CSS and JS for sidebar example

## Testing
- `composer install --no-interaction --ignore-platform-reqs`
- `vendor/bin/phpunit tests/ModelObjectExistTest.php` *(fails: PHPUnit_Framework_MockObject_MockBuilder::setMethods(): Implicitly marking parameter $methods as nullable is deprecated, the explicit nullable type must be used instead)*

------
https://chatgpt.com/codex/tasks/task_e_689b4b0a795883328f47e0f63c137d0f