### PR TITLE
Guard filesearch against missing directories

### DIFF
--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -629,15 +629,13 @@ if($_POST ){ //print_r($_SESSION['logged_incheck']);die;
 	
 
 
-	public function filesearch(){
-		$dir ="cripted/archivio";
-		$a = scandir($dir);
-       // Sort in descending order
-		$b = scandir($dir,1);//print_r($b);die;
-		$data['files'] = $b;
-		$data['title'] = "Search File";
-		$data['department'] = $this->model_object->getAll('dipartimenti');
-		$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
+       public function filesearch(){
+               $dir ="cripted/archivio";
+               // Sort in descending order and ensure result is always an array
+               $data['files'] = is_dir($dir) ? scandir($dir, 1) : [];
+               $data['title'] = "Search File";
+               $data['department'] = $this->model_object->getAll('dipartimenti');
+               $data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
 		
 		if($_SESSION['logged_incheck']['tipologiaUtente']=='admin'){
 			$data['certificat'] = $this->model_object->getAll('contenuto_certificato');	

--- a/application/views/admin/filesearch.php
+++ b/application/views/admin/filesearch.php
@@ -14,8 +14,8 @@ $this->load->model('model_object');
             </nav>
         </div>
 
-        <?php if (count($files) > 0) { ?>
-        <div class="row table-responsive">
+<?php if (!empty($files)) { ?>
+<div class="row table-responsive">
             <input type="text" id="myInput" onkeyup="myFunction()" placeholder="Search for names.." title="Type in a name" class="form-control mb-3">
             <table id="myTable" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
                 <?php
@@ -98,8 +98,10 @@ $this->load->model('model_object');
                 <?php $i++;
                 } ?>
             </table>
-        </div>
-        <?php } ?>
+</div>
+<?php } else { ?>
+<p>No files found.</p>
+<?php } ?>
     </div>
 </main>
 


### PR DESCRIPTION
## Summary
- Guard Admin::filesearch against missing directories
- Avoid `count()` on non-countables in file search view and show a message when no files are found

## Testing
- `php -l application/controllers/Admin.php`
- `php -l application/views/admin/filesearch.php`
- `./vendor/bin/phpunit tests/ModelObjectExistTest.php` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b5263a47c8332b8f3801c3d319c56