### PR TITLE
Handle empty file search results

### DIFF
--- a/application/views/admin/filesearch.php
+++ b/application/views/admin/filesearch.php
@@ -14,7 +14,7 @@ $this->load->model('model_object');
             </nav>
         </div>
 
-        <?php if (count($files) > 0) { ?>
+        <?php if (is_array($certificat) && count($certificat) > 0) { ?>
         <div class="row table-responsive">
             <input type="text" id="myInput" onkeyup="myFunction()" placeholder="Search for names.." title="Type in a name" class="form-control mb-3">
             <table id="myTable" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
@@ -99,6 +99,8 @@ $this->load->model('model_object');
                 } ?>
             </table>
         </div>
+        <?php } else { ?>
+        <div class="alert alert-info">No records found.</div>
         <?php } ?>
     </div>
 </main>


### PR DESCRIPTION
## Summary
- Safely verify that the certificate list is an array before rendering the table
- Show a friendly message when no records are found in file search

## Testing
- `composer install`
- `./vendor/bin/phpunit tests` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b531d35548332a510f69524ac6fe0