### PR TITLE
Handle missing archive directory in filesearch

### DIFF
--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -629,15 +629,25 @@ if($_POST ){ //print_r($_SESSION['logged_incheck']);die;
 	
 
 
-	public function filesearch(){
-		$dir ="cripted/archivio";
-		$a = scandir($dir);
-       // Sort in descending order
-		$b = scandir($dir,1);//print_r($b);die;
-		$data['files'] = $b;
-		$data['title'] = "Search File";
-		$data['department'] = $this->model_object->getAll('dipartimenti');
-		$data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
+        /**
+         * Display a list of archived files.
+         *
+         * Uses an absolute path based on FCPATH. If the archive directory is
+         * missing, the files list is empty and an error message is set.
+         */
+        public function filesearch(){
+                $dir = FCPATH.'cripted/archivio';
+
+                if (is_dir($dir)) {
+                        // Sort in descending order
+                        $data['files'] = scandir($dir,1); //print_r($data['files']);die;
+                } else {
+                        $data['files'] = [];
+                        $data['error'] = 'Archive directory not found.';
+                }
+                $data['title'] = "Search File";
+                $data['department'] = $this->model_object->getAll('dipartimenti');
+                $data['userinfo'] = $this->model_object->getElementById('utenti',$_SESSION['logged_incheck']['id']);
 		
 		if($_SESSION['logged_incheck']['tipologiaUtente']=='admin'){
 			$data['certificat'] = $this->model_object->getAll('contenuto_certificato');	


### PR DESCRIPTION
## Summary
- use FCPATH-based absolute path for filesearch archive directory
- guard `scandir` with `is_dir` to handle missing directories and record an error
- document new behavior in filesearch controller

## Testing
- `php -l application/controllers/Admin.php`
- `./vendor/bin/phpunit tests/ModelObjectExistTest.php` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b531f2bc483329c1e4710e86483fc