### PR TITLE
Use cookie-based remember me token

### DIFF
--- a/application/controllers/Signin.php
+++ b/application/controllers/Signin.php
@@ -63,12 +63,12 @@ class Signin extends CI_Controller {
     {
         $this->load->model(['model_object', 'model_user']);
 
-        if ($this->input->post('rememberme') === 'remember') {
+        if ($this->input->post('rememberme')) {
             set_cookie([
                 'name'   => 'remember_me_token',
                 'value'  => 'Random string',
                 'expire' => '1209600', // Two weeks
-                'domain' => 'cryptocert.oonthe.link/',
+                'domain' => 'cryptocert.oonthe.link',
                 'path'   => '/'
             ]);
         }

--- a/application/views/signin.php
+++ b/application/views/signin.php
@@ -33,7 +33,7 @@
 
                 <div class="mb-3">
                     <label class="form-checkbox-custom">
-                        <input type="checkbox" value="remember-me" id="remember_me">
+                        <input type="checkbox" value="remember-me" id="remember_me" name="rememberme">
                         <span class="form-label">Remember me</span>
                     </label>
                 </div>
@@ -55,33 +55,3 @@
 </div>
 </main>
 </div>
-
-<script src="https://code.jquery.com/jquery-1.9.1.js"></script>
-<script>
-    $(function() {
-
-        if (localStorage.chkbx && localStorage.chkbx != '') {
-            $('#remember_me').attr('checked', 'checked');
-            $('#loginEmail').val(localStorage.usrname);
-            $('#loginPassword').val(localStorage.pass);
-        } else {
-            $('#remember_me').removeAttr('checked');
-            $('#loginEmail').val('');
-            $('#loginPassword').val('');
-        }
-
-        $('#remember_me').click(function() {
-
-            if ($('#remember_me').is(':checked')) {
-                // save username and password
-                localStorage.usrname = $('#loginEmail').val();
-                localStorage.pass = $('#loginPassword').val();
-                localStorage.chkbx = $('#remember_me').val();
-            } else {
-                localStorage.usrname = '';
-                localStorage.pass = '';
-                localStorage.chkbx = '';
-            }
-        });
-    });
-</script>


### PR DESCRIPTION
## Summary
- Add `name="rememberme"` attribute to sign-in checkbox and drop localStorage logic
- Set remember-me token cookie only when the checkbox is checked and fix cookie domain

## Testing
- `vendor/bin/phpunit` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b640afb708332b1ea43a270115d2d