### PR TITLE
Add session check to Admin constructor

### DIFF
--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -21,14 +21,19 @@ class Admin extends CI_Controller {
     {
          parent::__construct();
     	 $this->load->helper('url');
-		 $this->load->library('session');
-		 $this->load->library('form_validation');	
-                $this->load->model('model_user');
-                $this->load->model('model_object');
+                $this->load->library('session');
+                $this->load->library('form_validation');
+               $this->load->model('model_user');
+               $this->load->model('model_object');
 
-                $currentTime = time();
-                $time_check = $currentTime - 600;
-                $login_time = $_SESSION['logged_incheck']['time'];
+               if (!isset($_SESSION['logged_incheck']) || !$this->session->userdata('logged_incheck')) {
+                       redirect('signin');
+                       exit;
+               }
+
+               $currentTime = time();
+               $time_check = $currentTime - 600;
+               $login_time = $_SESSION['logged_incheck']['time'];
 
                 if ($login_time < $time_check) {
                         redirect('install/unlock/');


### PR DESCRIPTION
## Summary
- verify `logged_incheck` session in `Admin::__construct`
- redirect to signin when user is not authenticated

## Testing
- `./vendor/bin/phpunit tests/ModelObjectExistTest.php` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b640f494c8332ad4338e19f6873cf