### PR TITLE
Use environment variables for database config

### DIFF
--- a/application/config/database.php
+++ b/application/config/database.php
@@ -75,10 +75,10 @@ $query_builder = TRUE;
 
 $db['default'] = array(
 	'dsn'	=> '',
-	'hostname' => 'HOSTNAME',
-	'username' => 'USERNAME',
-	'password' => 'PASSWORD',
-	'database' => 'DATABASE',
+	'hostname' => getenv('DB_HOST') ?: 'localhost',
+	'username' => getenv('DB_USER') ?: '',
+	'password' => getenv('DB_PASS') ?: '',
+	'database' => getenv('DB_NAME') ?: '',
 	'dbdriver' => 'mysqli',
 	'dbprefix' => '',
 	'pconnect' => FALSE,

--- a/application/config/database_sample - Copy.php
+++ b/application/config/database_sample - Copy.php
@@ -75,10 +75,10 @@ $query_builder = TRUE;
 
 $db['default'] = array(
 	'dsn'	=> '',
-	'hostname' => 'HOSTNAME',
-	'username' => 'USERNAME',
-	'password' => 'PASSWORD',
-	'database' => 'DATABASE',
+	'hostname' => getenv('DB_HOST') ?: 'localhost',
+	'username' => getenv('DB_USER') ?: '',
+	'password' => getenv('DB_PASS') ?: '',
+	'database' => getenv('DB_NAME') ?: '',
 	'dbdriver' => 'mysqli',
 	'dbprefix' => '',
 	'pconnect' => FALSE,


### PR DESCRIPTION
## Summary
- Load database connection settings from environment variables with sensible defaults
- Update sample configuration to use the same approach

## Testing
- `composer install`
- `./vendor/bin/phpunit --testdox` *(fails: Call to undefined function each() in vendor/phpunit/phpunit/src/Util/Getopt.php)*

------
https://chatgpt.com/codex/tasks/task_e_689b66381f6883328e639e25ce3da81c