### PR TITLE
Handle empty file search results

### DIFF
--- a/application/views/admin/filesearch.php
+++ b/application/views/admin/filesearch.php
@@ -14,7 +14,7 @@ $this->load->model('model_object');
             </nav>
         </div>
 
-<?php if (!empty($files)) { ?>
+<?php if (is_array($certificat) && count($certificat) > 0) { ?>
 <div class="row table-responsive">
             <input type="text" id="myInput" onkeyup="myFunction()" placeholder="Search for names.." title="Type in a name" class="form-control mb-3">
             <table id="myTable" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">


### PR DESCRIPTION
## Summary
- Ensure filesearch view checks `$certificat` results instead of undefined `$files`
- Display "No files found" when search yields no records

## Testing
- `vendor/bin/phpunit tests/ModelObjectExistTest.php` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b6a42293483329fc7360f47214b13