### PR TITLE
Include jQuery before admin scripts

### DIFF
--- a/application/views/admin/adminfooter.php
+++ b/application/views/admin/adminfooter.php
@@ -26,9 +26,10 @@ s0.parentNode.insertBefore(s1,s0);
 </script>
 <!--End of Tawk.to Script-->
     
-	<script src="https://cdn.ckeditor.com/4.10.1/standard/ckeditor.js"></script>
+        <script src="https://cdn.ckeditor.com/4.10.1/standard/ckeditor.js"></script>
 
-	<script src="<?=base_url()?>/assets/js/app.js"></script>
+        <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+        <script src="<?=base_url()?>/assets/js/app.js"></script>
 	<!-- <script src="<?=base_url()?>/node_modules/web3/dist/web3.min.js" type="module"></script>  -->
 	<script src="https://unpkg.com/@metamask/detect-provider/dist/detect-provider.min.js" type="module"></script>
 	<script type="text/javascript">


### PR DESCRIPTION
## Summary
- load jQuery in `adminfooter.php` so `$` is available for app.js and inline scripts

## Testing
- `php -l application/views/admin/adminfooter.php`
- `./vendor/bin/phpunit tests` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b6de7065483329259fa9a917cd176