### PR TITLE
Use base_url for admin view images

### DIFF
--- a/application/views/admin/adminheader.php
+++ b/application/views/admin/adminheader.php
@@ -278,7 +278,7 @@ php
 
 
 
-								<img src="images/avatar-3.jpg" alt="">
+								<img src="<?= base_url('images/avatar-3.jpg') ?>" alt="">
 
 
 
@@ -338,7 +338,7 @@ php
 
 
 
-								<img src="images/avatar-3.jpg" alt="">
+								<img src="<?= base_url('images/avatar-3.jpg') ?>" alt="">
 
 
 

--- a/application/views/admin/dashboard.php
+++ b/application/views/admin/dashboard.php
@@ -145,7 +145,7 @@
 					<div class="col-lg-6">
 						<div class="card card-reverse">
 							<div class="card-image transition-left">
-								<img src="images/stock-2.jpg" alt="">
+								<img src="<?= base_url('images/stock-2.jpg') ?>" alt="">
 							</div>
 							<div class="card-body">
 								<h3>Lorem ipsum dolor.</h3>
@@ -153,7 +153,7 @@
 								<div class="user-panel">
 									<div class="user-panel-image">
 										<div class="avatar avatar-sm">
-											<img src="images/avatar-1.jpg" alt="">
+											<img src="<?= base_url('images/avatar-1.jpg') ?>" alt="">
 										</div>
 									</div>
 									<div class="user-panel-info">
@@ -172,7 +172,7 @@
 					<div class="col-lg-6">
 						<div class="card">
 							<div class="card-image transition-right">
-								<img src="images/stock-4.jpg" alt="">
+								<img src="<?= base_url('images/stock-4.jpg') ?>" alt="">
 							</div>
 							<div class="card-body">
 								<h3>Lorem ipsum dolor.</h3>
@@ -180,7 +180,7 @@
 								<div class="user-panel">
 									<div class="user-panel-image">
 										<div class="avatar avatar-sm">
-											<img src="images/avatar-1.jpg" alt="">
+											<img src="<?= base_url('images/avatar-1.jpg') ?>" alt="">
 										</div>
 									</div>
 									<div class="user-panel-info">
@@ -354,7 +354,7 @@
 									</div>
 									<div class="message">
 										<div class="avatar avatar-sm">
-											<img src="images/avatar-3.jpg" alt="">
+											<img src="<?= base_url('images/avatar-3.jpg') ?>" alt="">
 										</div>
 										<div class="message-content">
 											<div class="message-bubble">
@@ -412,7 +412,7 @@
 								</div>
 								<div class="event-column event-column-success">
 									<div class="avatar avatar-xs">
-										<img src="images/avatar-2.jpg" alt="">
+										<img src="<?= base_url('images/avatar-2.jpg') ?>" alt="">
 									</div>
 									<div class="event-content">
 										<small class="text-secondary"><i class="fas fa-code-branch"></i> awesome-branch</small>
@@ -479,7 +479,7 @@
 								<div class="user-panel">
 									<div class="user-panel-image">
 										<div class="avatar avatar-sm">
-											<img src="images/avatar-2.jpg" alt="">
+											<img src="<?= base_url('images/avatar-2.jpg') ?>" alt="">
 											<i class="fas fa-circle text-success"></i>
 										</div>
 									</div>
@@ -494,7 +494,7 @@
 								<div class="user-panel">
 									<div class="user-panel-image">
 										<div class="avatar avatar-sm">
-											<img src="images/avatar-3.jpg" alt="">
+											<img src="<?= base_url('images/avatar-3.jpg') ?>" alt="">
 										</div>
 									</div>
 									<div class="user-panel-info">
@@ -508,7 +508,7 @@
 								<div class="user-panel">
 									<div class="user-panel-image">
 										<div class="avatar avatar-sm">
-											<img src="images/avatar-4.jpg" alt="">
+											<img src="<?= base_url('images/avatar-4.jpg') ?>" alt="">
 											<i class="fas fa-circle text-success"></i>
 										</div>
 									</div>
@@ -523,7 +523,7 @@
 								<div class="user-panel">
 									<div class="user-panel-image">
 										<div class="avatar avatar-sm">
-											<img src="images/avatar-6.jpg" alt="">
+											<img src="<?= base_url('images/avatar-6.jpg') ?>" alt="">
 										</div>
 									</div>
 									<div class="user-panel-info">
@@ -537,7 +537,7 @@
 								<div class="user-panel">
 									<div class="user-panel-image">
 										<div class="avatar avatar-sm">
-											<img src="images/avatar-7.jpg" alt="">
+											<img src="<?= base_url('images/avatar-7.jpg') ?>" alt="">
 										</div>
 									</div>
 									<div class="user-panel-info">
@@ -551,7 +551,7 @@
 								<div class="user-panel">
 									<div class="user-panel-image">
 										<div class="avatar avatar-sm">
-											<img src="images/avatar-8.jpg" alt="">
+											<img src="<?= base_url('images/avatar-8.jpg') ?>" alt="">
 										</div>
 									</div>
 									<div class="user-panel-info">
@@ -565,7 +565,7 @@
 								<div class="user-panel">
 									<div class="user-panel-image">
 										<div class="avatar avatar-sm">
-											<img src="images/avatar-9.jpg" alt="">
+											<img src="<?= base_url('images/avatar-9.jpg') ?>" alt="">
 										</div>
 									</div>
 									<div class="user-panel-info">


### PR DESCRIPTION
## Summary
- Load admin header avatars via `base_url`
- Use `base_url` for all dashboard image references

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b6de7bc248332bd2663555fcc54ee