### PR TITLE
Remove search results stub from admin header

### DIFF
--- a/application/views/admin/adminheader.php
+++ b/application/views/admin/adminheader.php
@@ -1,34 +1,5 @@
-php
 <!DOCTYPE html>
-<html>
-<head>
-    <title>Search Results</title>
-    <!-- Add your styles -->
-</head>
-<body>
-
-    <h1>Search Results</h1>
-
-    <?php if (isset($results) && !empty($results)): ?>
-        <ul>
-        <?php foreach ($results as $result): ?>
-            <li><?= $result->name ?></li> <!-- modify based on your data -->
-        <?php endforeach; ?>
-        </ul>
-    <?php else: ?>
-        <p>No results found.</p>
-    <?php endif; ?>
-
-</body>
-</html>
-<!DOCTYPE html>
-
-
-
 <html lang="en">
-
-
-
 <head>
 
 
@@ -610,4 +581,4 @@ php
 
 
 
-		</header>
+                </header>


### PR DESCRIPTION
## Summary
- strip leftover search results snippet from adminheader.php so it begins with proper admin layout markup

## Testing
- `php -l application/views/admin/adminheader.php`
- `vendor/bin/phpunit` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b6dec03f4833295de0f31789fb69b