### PR TITLE
Fix invalid Tawk.to embed script in admin footer

### DIFF
--- a/application/views/admin/adminfooter.php
+++ b/application/views/admin/adminfooter.php
@@ -18,7 +18,7 @@ var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
 (function(){
 var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
 s1.async=true;
-s1.src='https://embed.tawk.to/5bc61d9061d0b77092516943/default';
+s1.src='https://embed.tawk.to/521727297ca1334016000005/18nms7gql';
 s1.charset='UTF-8';
 s1.setAttribute('crossorigin','*');
 s0.parentNode.insertBefore(s1,s0);


### PR DESCRIPTION
## Summary
- update Tawk.to chat snippet with a valid property and widget ID

## Testing
- `curl -I https://embed.tawk.to/521727297ca1334016000005/18nms7gql`
- `composer install`
- `vendor/bin/phpunit` *(fails: Call to undefined function each()*

------
https://chatgpt.com/codex/tasks/task_e_689b6dfab6708332a05ffc5351935b77