### PR TITLE
Handle empty file search results

### DIFF
--- a/application/views/admin/adminheader.php
+++ b/application/views/admin/adminheader.php
@@ -1,34 +1,5 @@
-php
 <!DOCTYPE html>
-<html>
-<head>
-    <title>Search Results</title>
-    <!-- Add your styles -->
-</head>
-<body>
-
-    <h1>Search Results</h1>
-
-    <?php if (isset($results) && !empty($results)): ?>
-        <ul>
-        <?php foreach ($results as $result): ?>
-            <li><?= $result->name ?></li> <!-- modify based on your data -->
-        <?php endforeach; ?>
-        </ul>
-    <?php else: ?>
-        <p>No results found.</p>
-    <?php endif; ?>
-
-</body>
-</html>
-<!DOCTYPE html>
-
-
-
 <html lang="en">
-
-
-
 <head>
 
 

--- a/application/views/admin/filesearch.php
+++ b/application/views/admin/filesearch.php
@@ -14,9 +14,9 @@ $this->load->model('model_object');
             </nav>
         </div>
 
-<?php if (!empty($files)) { ?>
+<?php if (is_array($certificat) && count($certificat) > 0) { ?>
 <div class="row table-responsive">
-            <input type="text" id="myInput" onkeyup="myFunction()" placeholder="Search for names.." title="Type in a name" class="form-control mb-3">
+            <input type="text" id="myInput" placeholder="Search for names.." title="Type in a name" class="form-control mb-3">
             <table id="myTable" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
                 <?php
                 $i = 1;
@@ -106,6 +106,8 @@ $this->load->model('model_object');
 </main>
 
 <script>
+    document.getElementById("myInput").addEventListener("keyup", myFunction);
+
 function myFunction() {
     var input, filter, table, tr, td, i, txtValue;
     input = document.getElementById("myInput");


### PR DESCRIPTION
## Summary
- Ensure filesearch view checks `$certificat` results instead of undefined `$files`
- Display "No files found" when search yields no records
- Remove extraneous markup and add DOCTYPE to admin header to avoid Quirks Mode
- Replace inline keyup handler with JS listener for stricter CSP

## Testing
- `vendor/bin/phpunit tests/ModelObjectExistTest.php` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_689b6a42293483329fc7360f47214b13